### PR TITLE
Arguments can now be passed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,8 @@ const docker = require('./docker');
 const HostNamesFileOperator = require('./hosts');
 const DockerContainerHostNamesSynchronizer = require('./sync');
 
-(async function main(...args) {
-    args = args.slice(2);
+(async function main() {
+    const args = process.argv.slice(2);
     console.log(`Synchronizing docker container hostnames in hosts file.`);
     await syncDockerHosts(args[0]);
 })();


### PR DESCRIPTION
Currently arguments are not being passed so you cannot change the path to the hostfile. This is because [process.argv](https://nodejs.org/docs/latest/api/process.html#process_process_argv) is not used.